### PR TITLE
Add Hivekeep

### DIFF
--- a/categories.json
+++ b/categories.json
@@ -108,5 +108,6 @@
   "XiaomiMiMo/MiMo-Code": "Coding",
   "elder-plinius/T3MP3ST": "Cybersecurity",
   "transformerlab/transformerlab-app": "Machine Learning",
-  "multica-ai/multica": "Multi-Agent"
+  "multica-ai/multica": "Multi-Agent",
+  "MarlBurroW/hivekeep": "Agent Platform"
 }

--- a/repos.json
+++ b/repos.json
@@ -108,6 +108,7 @@
     "XiaomiMiMo/MiMo-Code",
     "elder-plinius/T3MP3ST",
     "transformerlab/transformerlab-app",
-    "multica-ai/multica"
+    "multica-ai/multica",
+    "MarlBurroW/hivekeep"
   ]
 }


### PR DESCRIPTION
Adds Hivekeep to the tracked repos.

Hivekeep is a self-hosted, MIT-licensed platform to run a team of specialized AI agents with persistent memory and a web UI; agents collaborate and build their own tools, mini-apps and plugins, and are reachable over Telegram, Slack, Discord and Matrix from a single container (Bun + SQLite).

Repo: https://github.com/MarlBurroW/hivekeep

The README is generated, so this edits the source of truth: added MarlBurroW/hivekeep to repos.json and categorized it as "Agent Platform" in categories.json. Disclosure: I am the author of Hivekeep.