### PR TITLE
fix(categories): drop orphan entry not in repos.json

### DIFF
--- a/categories.json
+++ b/categories.json
@@ -101,7 +101,6 @@
   "bytedance/UI-TARS-desktop": "Computer Control",
   "danny-avila/LibreChat": "Chat Interface",
   "agent0ai/agent-zero": "Agent Framework",
-  "pewdiepie-odysseus/odysseus": "Agent Framework",
   "CopilotKit/CopilotKit": "Agent Framework",
   "ag-ui-protocol/ag-ui": "Agent Framework",
   "youssofal/MTPLX": "LLM Runtime",


### PR DESCRIPTION
## Problem

`categories.json` and `repos.json` are meant to cover the same set of repositories, but they were out of sync:

- `repos.json` lists **108** repositories.
- `categories.json` had **109** entries.
- The extra entry, `pewdiepie-odysseus/odysseus`, is **not** in `repos.json`, does **not** appear in any README (`README.md`, `README_RU.md`, `README_ZH.md`), and the repository returns **404 on GitHub** (it does not exist).

The most recent commit is titled *"Update 108 repos"*, confirming the intended count is 108. The orphan looks like a leftover from when the repo was removed everywhere else but not from `categories.json`.

## Fix

Remove the single orphan entry so `categories.json` (108) matches `repos.json` (108) and the READMEs:

```diff
   "agent0ai/agent-zero": "Agent Framework",
-  "pewdiepie-odysseus/odysseus": "Agent Framework",
   "CopilotKit/CopilotKit": "Agent Framework",
```

After the change, the key sets of `repos.json` and `categories.json` are identical (verified: no keys in one and not the other, no duplicates, valid JSON).
