### PR TITLE
Add Atomic Agent to Coding

### DIFF
--- a/categories.json
+++ b/categories.json
@@ -112,5 +112,6 @@
   "poolsideai/pool": "Coding",
   "yc-software/qm": "Agent Platform",
   "noumena-labs/Sipp": "LLM Runtime",
-  "swe-agent/mini-swe-agent": "Coding"
+  "swe-agent/mini-swe-agent": "Coding",
+  "AtomicBot-ai/atomic-agent": "Coding"
 }

--- a/repos.json
+++ b/repos.json
@@ -112,6 +112,7 @@
     "poolsideai/pool",
     "yc-software/qm",
     "noumena-labs/Sipp",
-    "swe-agent/mini-swe-agent"
+    "swe-agent/mini-swe-agent",
+    "AtomicBot-ai/atomic-agent"
   ]
 }


### PR DESCRIPTION
Adds Atomic Agent to the source catalog.

Hi! I'm the CPO of Atomic Agent. Thanks for putting this list together, the daily star and freshness tracking is genuinely useful. Our team would be thrilled if you added us.

Atomic Agent is a local-first CLI and TUI coding assistant. It runs open-weight models entirely on your machine through a llama.cpp fork, so no account or API key is required to install or run it. It ships 56 built-in tools (browser, filesystem, git, memory, vision), supports MCP, and has a five layer local memory system. The TUI is built on React and ink.

Honest note: the project is currently in developer preview, so APIs, commands, config, and behavior are still moving.

- Repo: https://github.com/AtomicBot-ai/atomic-agent
- Stars: ~2k, MIT, TypeScript, actively maintained
- Platforms: macOS, Linux, Windows
- Install: `curl -fsSL https://atomicagent.io/install | sh`
- Site: https://atomicagent.io
- Docs: https://atomicagent.io/docs

Suggested category: **Coding**, alongside claude-code, aider, opencode, crush, and mini-swe-agent. It is an end-user coding agent rather than a library you build agents with, so Coding looked like the right fit over Agent Framework. Happy to move it if you prefer a different bucket.

Validation:
- Updated `repos.json` with the canonical repository
- Updated `categories.json` with `Coding`
- Both files still parse as valid JSON, no duplicate entries, every repo has a category

Note: the README files appear to be generated from the catalog data, so this PR touches the source data only and leaves README.md, README_RU.md, and README_ZH.md for your generator to rebuild.
