### PR TITLE
Add SandBase Harness to agent frameworks

### DIFF
--- a/repos.json
+++ b/repos.json
@@ -118,6 +118,7 @@
     "ShenSeanChen/waku-agent",
     "semantica-agi/semantica",
     "deepseek-ai/deepseek-harness",
+    "sandbaseai/sandbase-harness",
     "moeru-ai/airi",
     "vercel-labs/fx",
     "FlashML-org/FreeToken"


### PR DESCRIPTION
## Summary
- add `sandbaseai/sandbase-harness` to the repository source list
- allow the project's existing ranking/readme generation to include the local-first agent runtime

## Verification
- Official repository: https://github.com/sandbaseai/sandbase-harness
- Current release: v0.3.8
- `repos.json` remains valid JSON.
